### PR TITLE
Jack

### DIFF
--- a/docs/milestone-documentation-Jack/Jan_21_2025.txt
+++ b/docs/milestone-documentation-Jack/Jan_21_2025.txt
@@ -1,0 +1,5 @@
+Jack canalori - 1/21/2025
+
+Today I dowloaded GitHubDesktop, Vulcan, and CMake, as well as downloaded the provided zip files. 
+I also set up my VSCode envirnment. I also downloaded the compiler used for this project. I also looked through 
+a tuturial on how to use Vulcan. This took 1.5 hours to download all of the necessary components.  

--- a/source/engine/src/deviceSetup.cpp
+++ b/source/engine/src/deviceSetup.cpp
@@ -206,7 +206,7 @@ namespace JCAT {
         VkPhysicalDeviceProperties deviceProperties;
         vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);
         std::cout << "Choosing the following GPU: " << deviceProperties.deviceName << std::endl;
-        properties = deviceProperties;
+        properties = deviceProperties; 
     }
 
     void DeviceSetup::createLogicalDevice() {
@@ -294,13 +294,30 @@ namespace JCAT {
             SwapChainSupportDetails swapChainSupport = querySwapChainSupport(device);
             swapChainAdequate = !swapChainSupport.formats.empty() && !swapChainSupport.presentModes.empty();
         }
+        else
+        {
+            std::cerr << "Device does not support the required extensions!" << std::endl; //determine which part if any causes a false return
+        }
 
         VkPhysicalDeviceFeatures supportedFeatures;
         vkGetPhysicalDeviceFeatures(device, &supportedFeatures);
         
         bool samplerAnisotropySupported = supportedFeatures.samplerAnisotropy;
+        if(!samplerAnisotropySupported)
+        {
+            std::cerr << "Device does not support sampler anisotropy!" << std::endl; //determine which part if any causes a false return
+        }
         bool sampleRateSahdingSupported = supportedFeatures.sampleRateShading;
+        if(!sampleRateSahdingSupported)
+        {
+            std::cerr << "Device does not support sample rate shading!" << std::endl;//determine which part if any causes a false return
+        }
         bool geometryShaderSupported = supportedFeatures.geometryShader;
+        if(!geometryShaderSupported)
+        {
+            std::cerr << "Device does not support geometry shaders!" << std::endl;//determine which part if any causes a false return
+        }
+        
 
         return indices.isComplete() && extensionsSupported && samplerAnisotropySupported && sampleRateSahdingSupported && geometryShaderSupported;
     }

--- a/source/engine/src/swapChain.cpp
+++ b/source/engine/src/swapChain.cpp
@@ -191,8 +191,24 @@ namespace JCAT {
         return sameFormat;
     }
 
+
+    
     void SwapChain::createSwapChain() {
         SwapChainSupportDetails swapChainSupport = device.getSwapChainSupport();
+
+    //  Print supported surface formats
+    std::cout << "Supported Surface Formats:" << std::endl;
+    for (const auto& format : swapChainSupport.formats) 
+    {
+        std::cout << "Format: " << format.format << ", Color Space: " << format.colorSpace << std::endl;
+    }
+
+    // Print supported present modes
+    std::cout << "Supported Present Modes:" << std::endl;
+    for (const auto& mode : swapChainSupport.presentModes) 
+    {
+        std::cout << "Present Mode: " << mode << std::endl;
+    }
 
         VkSurfaceFormatKHR surfaceFormat = chooseSwapSurfaceFormat(swapChainSupport.formats);
         VkPresentModeKHR presentMode = chooseSwapPresentMode(swapChainSupport.presentModes);
@@ -216,6 +232,11 @@ namespace JCAT {
         createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
         QueueFamilyIndices indices = device.findPhysicalQueueFamilies();
+
+         // Debug: Print queue family indices
+         std::cout << "Graphics Family Index: " << indices.graphicsFamily << std::endl;
+        std::cout << "Present Family Index: " << indices.presentFamily << std::endl;
+
         uint32_t queueFamilyIndices[] = { indices.graphicsFamily, indices.presentFamily };
 
         if (indices.graphicsFamily != indices.presentFamily) {
@@ -231,8 +252,35 @@ namespace JCAT {
 
         createInfo.preTransform = swapChainSupport.capabilities.currentTransform;
 
+
+        // Choose a supported composite alpha mode
+    VkCompositeAlphaFlagBitsKHR compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    if (!(swapChainSupport.capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)) 
+    {
+        // try other supported modes
+        if (swapChainSupport.capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR) 
+        {
+            compositeAlpha = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR;
+        } 
+        else if (swapChainSupport.capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR) 
+        {
+            compositeAlpha = VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR;
+        } 
+        else if (swapChainSupport.capabilities.supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) 
+        {
+            compositeAlpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
+        } 
+        else 
+        {
+            throw std::runtime_error("No supported composite alpha mode found!");
+        }
+    }
+
+    // Use the chosen composite alpha mode
+    createInfo.compositeAlpha = compositeAlpha;
+
         // Will need to change later to allow transparency through alpha channels.
-        createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR;
+       // createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR;
 
         createInfo.presentMode = presentMode;
         createInfo.clipped = VK_TRUE;
@@ -240,7 +288,10 @@ namespace JCAT {
         // Handle the previous swap chain
         createInfo.oldSwapchain = previousSwapChain == nullptr ? VK_NULL_HANDLE : previousSwapChain->swapChain;
 
-        if (vkCreateSwapchainKHR(device.device(), &createInfo, nullptr, &swapChain) != VK_SUCCESS) {
+        if (vkCreateSwapchainKHR(device.device(), &createInfo, nullptr, &swapChain) != VK_SUCCESS) 
+        {
+            // Print more information about the failure
+             std::cerr << "Failed to create swap chain! Error code: " << vkCreateSwapchainKHR(device.device(), &createInfo, nullptr, &swapChain) << std::endl;
             throw std::runtime_error("Failed to create the swap chain!");
         }
 
@@ -516,6 +567,8 @@ namespace JCAT {
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));
+
+             std::cout << "Chosen Swap Extent: " << actualExtent.width << "x" << actualExtent.height << std::endl;
 
             return actualExtent;
         }


### PR DESCRIPTION
I fixed the error that would not create the swap chain when ran on a device with an AMD GPU because the code did not choose an alpha mode based on the physical device. I fixed the error by allowing the appropriate alpha mode to be selected based on the device. I also included more print statements that would hopefully provide better help for any future swap chain issues